### PR TITLE
fix: Replica nodes should be correctly initalized

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
-      <version>2.9.0</version>
+      <version>3.6.0</version>
     </dependency>
 
     <!-- TEST DEPENDENCIES -->

--- a/src/main/java/redis/embedded/RedisCluster.java
+++ b/src/main/java/redis/embedded/RedisCluster.java
@@ -4,15 +4,12 @@ import com.google.common.collect.Lists;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Pipeline;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.commands.ProtocolCommand;
 import redis.embedded.exceptions.EmbeddedRedisException;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.IntStream;
 
-import org.springframework.data.redis.connection.convert.ListConverter;
 
 public class RedisCluster implements Redis {
     private final List<Redis> servers = new LinkedList<Redis>();
@@ -164,6 +161,10 @@ public class RedisCluster implements Redis {
         ports.addAll(slavesPorts);
         return ports;
     }
+
+	public List<Redis> getServers() {
+		return servers;
+	}
 
     public static RedisClusterBuilder builder() {
         return new RedisClusterBuilder();

--- a/src/test/java/redis/embedded/RedisClusterTest.java
+++ b/src/test/java/redis/embedded/RedisClusterTest.java
@@ -126,5 +126,6 @@ public class RedisClusterTest {
     @After
     public void tearDown() throws Exception {
 		this.cluster.stop();
+		this.ephemeralCluster.stop();
     }
 }

--- a/src/test/java/redis/embedded/RedisClusterTest.java
+++ b/src/test/java/redis/embedded/RedisClusterTest.java
@@ -1,14 +1,18 @@
 package redis.embedded;
 
+import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import redis.clients.jedis.*;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class RedisClusterTest {
 	private RedisCluster cluster;
@@ -66,6 +70,55 @@ public class RedisClusterTest {
 		} finally {
 			if (jc != null) {
 				jc.close();
+			}
+		}
+	}
+
+	@Test
+	public void testClusterRolesAreCorrectlyInitialized() {
+		Jedis j = null;
+
+		try {
+			j = new Jedis("127.0.0.1", 7001);
+			String[] clusterNodes = j.clusterNodes().split("\n");
+			Map<String, Integer> nodeIdToPort = new HashMap<>();
+			Map<Integer, String> replicas = new HashMap<>();
+			for (String node:clusterNodes) {
+				// Expected line format from Redis docs (one line - one node)
+				// 292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f 127.0.0.1:30003@31003 master - 0 1426238318243 3 connected 10923-16383
+				// 6ec23923021cf3ffec47632106199cb7f496ce01 127.0.0.1:30005@31005 slave 67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1 0 1426238316232 5 connected
+				String[] parts = node.split(" ");
+				if (parts.length < 3) {
+					continue;
+				}
+
+				Integer nodePort = Integer.parseInt(parts[1].split("@")[0].split(":")[1]);
+				List<String> nodeTags = Lists.newArrayList(parts[2].split(","));
+
+				nodeIdToPort.put(parts[0], nodePort);
+
+				String replicaOf = parts[3];
+
+				if (nodePort > 8000) {
+					assertTrue("Node must be a replica", nodeTags.contains("slave"));
+					replicas.put(nodePort, replicaOf);
+
+				} else {
+					assertTrue(nodeTags.contains("master"));
+				}
+			}
+
+			for (Map.Entry<Integer, String> replica:replicas.entrySet()) {
+				// replica port - 1000 == master port
+				assertEquals(
+					Long.valueOf(replica.getKey() - 1000),
+					Long.valueOf(nodeIdToPort.get(replica.getValue()))
+				);
+			}
+
+		} finally {
+			if (j != null) {
+				j.close();
 			}
 		}
 	}


### PR DESCRIPTION
Replica nodes should be correctly initialized - explicit set to replicate their masters.

Current behavior: all nodes started as masters.